### PR TITLE
permission update

### DIFF
--- a/org.stellarium.Stellarium.json
+++ b/org.stellarium.Stellarium.json
@@ -13,7 +13,8 @@
         "--share=network",
         "--device=dri",
         "--socket=pulseaudio",
-        "--filesystem=home"
+        "--filesystem=~/.stellarium:create",
+        "--filesystem=xdg-pictures"
     ],
     "cleanup": [
         "/include",


### PR DESCRIPTION
- ~~home access was unnecessary (#1), `--persist=.stellarium` would have sufficed.~~
- ~~KDE Runtime updated to 5.14, closes #6~~

-- edit --
Dropped the commit to update runtime since it's no longer needed.
The only commit left is the permission one which keeps compatibility with previous installations.